### PR TITLE
Reload on create

### DIFF
--- a/src/extension/pdf-preview.ts
+++ b/src/extension/pdf-preview.ts
@@ -66,6 +66,13 @@ export class PdfPreview extends Disposable {
       })
     )
     this._register(
+      watcher.onDidCreate((e) => {
+        if (e.toString() === this.resource.toString()) {
+          this.reload()
+        }
+      })
+    )
+    this._register(
       watcher.onDidDelete((e) => {
         if (e.toString() === this.resource.toString()) {
           this.webviewEditor.dispose()


### PR DESCRIPTION
Adding `watcher.onDidCreate` where it was just `watcher.onDidChange` fixes [The PDF does not refresh #115](https://github.com/lhl2617/VSLilyPond-PDF-preview/issues/115) for me.

I didn't look into it deeply enough to see if both were needed or if just `watcher.onDidCreate` was sufficient, but this works for both cases.